### PR TITLE
Supported shouldOverrideUrlLoadingSynchronousMethodEnabled in Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -973,7 +973,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       final RNCWebView rncWebView = (RNCWebView) view;
       final boolean isJsDebugging = ((ReactContext) view.getContext()).getJavaScriptContextHolder().get() == 0;
 
-      if (!isJsDebugging && rncWebView.mCatalystInstance != null && !mShouldOverrideUrlLoadingSynchronousMethodEnabled) {
+      if (!isJsDebugging && rncWebView.mCatalystInstance != null && mShouldOverrideUrlLoadingSynchronousMethodEnabled) {
         final Pair<Integer, AtomicReference<ShouldOverrideCallbackState>> lock = RNCWebViewModule.shouldOverrideUrlLoadingLock.getNewLock();
         final int lockIdentifier = lock.first;
         final AtomicReference<ShouldOverrideCallbackState> lockObject = lock.second;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -341,6 +341,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   downloadingMessage?: string;
   lackPermissionToDownloadMessage?: string;
   allowsProtectedMedia?: boolean;
+  shouldOverrideUrlLoadingSynchronousMethodEnabled?: boolean;
 }
 
 export declare type ContentInsetAdjustmentBehavior =
@@ -1127,6 +1128,13 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   allowsProtectedMedia?: boolean;
+
+  /**
+   * Boolean value to control whether Webview#shouldOverrideUrlLoading callbacks will be executed synchronously
+   * Default is false.
+   * @platform android
+   */
+  shouldOverrideUrlLoadingSynchronousMethodEnabled?: boolean;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
Supported `ReactProps`: `shouldOverrideUrlLoadingSynchronousMethodEnabled`  in Android to control whether enable synchronous method invoking or not